### PR TITLE
Minor fix to make the chisq cdf work on platforms other than os x

### DIFF
--- a/cdf_chisqt/cdf_base.cpp
+++ b/cdf_chisqt/cdf_base.cpp
@@ -3,6 +3,8 @@
 #include<string.h>
 #include<ostream>
 #include<iomanip>
+#include<climits>
+#include<cmath>
 
 /*
  * All of this code has been taken from the R Core library with
@@ -5088,7 +5090,8 @@ double qchisq(double p, double df, int lower_tail, int log_p)
 #define R_D_qIv(p)	(log_p	? exp(p) : (p))		/*  p  in qF(p,..) */
 
 double tanpi(double x) {
-    return __tanpi(x);
+//    return __tanpi(x);
+    return tan(M_PI*x);
 }
 
 


### PR DESCRIPTION
New include clauses were added to the main .cpp file in chisq section. 

Now, M_PI*tan(x) from cmath is used instead of tanpi function, which is not available at many systems.
#include <climits> was added - now minimal example runs correctly.
Numerical results were checked with previous version.